### PR TITLE
add missing columns to user_config

### DIFF
--- a/db/migration/1607791764966-createUserConfigTable.ts
+++ b/db/migration/1607791764966-createUserConfigTable.ts
@@ -18,6 +18,14 @@ export class createUserConfigTable1607791764966 implements MigrationInterface {
           type: 'varchar',
           length: '45',
         },
+        {
+          name: 'nano_site_name',
+          type: 'varchar',
+        },
+        {
+          name: 'cross_guild',
+          type: 'boolean',
+        },
       ],
     })
 

--- a/src/models/user-config.ts
+++ b/src/models/user-config.ts
@@ -26,9 +26,32 @@ export class UserConfig extends BaseEntity {
    */
   @Column({
     length: 45,
+    nullable: true,
     type: 'varchar',
   })
   timezone?: IANAZone
+
+  /**
+   * The user's name on the NaNoWriMo site.
+   */
+  @Column({
+    name: 'nano_site_name',
+    nullable: true,
+    type: 'varchar',
+  })
+  nanoSiteName?: string
+
+  /**
+   * Whether or not challenges created by this user are automatically hidden.
+   *
+   * Can be overridden by GuildConfig#crossGuild
+   */
+  @Column({
+    name: 'cross_guild',
+    default: true,
+    type: 'bool',
+  })
+  crossGuild = true
 
   /**
    * Finds the config object for a given user id.


### PR DESCRIPTION
Adds the missing `crossGuild` and `nanoSiteName` columns to the user config model.

I'll be adding validations in a follow up PR