### PR TITLE
Add Validations for guildConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Provides commands for Discord-based writing groups, including word wars, sprints and goals. Created for NaNoWriMo Melbourne Region",
   "main": "dist/src/index.js",
   "dependencies": {
+    "class-validator": "^0.12.2",
     "discord.js": "^12.4.0",
     "i18next": "^19.8.4",
     "i18next-fs-backend": "^1.0.7",

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -5,6 +5,8 @@ import i18next from 'i18next'
  * Functionality related to localizing Winnie
  */
 export default class I18n {
+  static SUPPORTED_LANGUAGES = ['en', 'fr', 'hu', 'nl', 'sv']
+
   /**
    * Initializes the logger and sets default configurations
    */
@@ -17,7 +19,7 @@ export default class I18n {
       lng: 'en',
       ns: ['commands', 'winnie'],
       preload: ['en'],
-      supportedLngs: ['en', 'fr', 'hu', 'nl', 'sv'],
+      supportedLngs: this.SUPPORTED_LANGUAGES,
     })
   }
 

--- a/src/models/base-model.ts
+++ b/src/models/base-model.ts
@@ -1,0 +1,21 @@
+import { BaseEntity, SaveOptions } from 'typeorm'
+import { ValidationError, validate } from 'class-validator'
+
+export class BaseModel extends BaseEntity {
+  errors: Array<ValidationError> = []
+
+  async validate(): Promise<this> {
+    this.errors = await validate(this)
+    return this
+  }
+
+  async save(options?: SaveOptions): Promise<this> {
+    await this.validate()
+
+    if (this.errors.length <= 0) {
+      await super.save(options)
+    }
+
+    return this
+  }
+}

--- a/src/models/guild-config.ts
+++ b/src/models/guild-config.ts
@@ -3,6 +3,7 @@ import { BaseModel } from './base-model'
 import { Column, Entity, PrimaryColumn } from 'typeorm'
 import { IANAZone } from 'luxon'
 import { IsIn, IsOptional, Length, MaxLength } from 'class-validator'
+import { IsTimeZone } from './validators/time-zone'
 import { Snowflake } from 'discord.js'
 
 /**
@@ -61,6 +62,7 @@ export class GuildConfig extends BaseModel {
    */
   @Column({ type: 'varchar' })
   @IsOptional()
+  @IsTimeZone()
   timezone?: IANAZone
 
   /**

--- a/src/models/guild-config.ts
+++ b/src/models/guild-config.ts
@@ -1,29 +1,27 @@
-import { BaseEntity, Column, Entity, PrimaryColumn } from 'typeorm'
+import I18n from '../core/i18n'
+import { BaseModel } from './base-model'
+import { Column, Entity, PrimaryColumn } from 'typeorm'
 import { IANAZone } from 'luxon'
+import { IsIn, IsOptional, Length, MaxLength } from 'class-validator'
 import { Snowflake } from 'discord.js'
 
 /**
  * Stores various settings specific to a guild.
  */
 @Entity()
-export class GuildConfig extends BaseEntity {
+export class GuildConfig extends BaseModel {
   /**
    * The Discord ID of the guild this configuration object represents.
    */
-  @PrimaryColumn({
-    length: 30,
-    type: 'varchar',
-  })
+  @PrimaryColumn({ type: 'varchar' })
+  @MaxLength(30)
   id!: Snowflake
 
   /**
    * The string which should be used as the command prefix for this guild
    */
-  @Column({
-    default: '!',
-    length: 3,
-    type: 'varchar',
-  })
+  @Column({ type: 'varchar' })
+  @Length(1, 3)
   prefix = '!'
 
   /**
@@ -31,11 +29,9 @@ export class GuildConfig extends BaseEntity {
    *
    * Channel where Winnie sends daily goals and other announcements
    */
-  @Column({
-    name: 'announcements_channel_id',
-    length: 30,
-    type: 'varchar',
-  })
+  @Column({ name: 'announcements_channel_id', type: 'varchar' })
+  @MaxLength(30)
+  @IsOptional()
   announcementsChannelId?: Snowflake
 
   /**
@@ -51,11 +47,8 @@ export class GuildConfig extends BaseEntity {
   /**
    * The locale to use for messages sent to this guild
    */
-  @Column({
-    default: 'en',
-    length: 2,
-    type: 'varchar',
-  })
+  @Column({ type: 'varchar' })
+  @IsIn(I18n.SUPPORTED_LANGUAGES)
   locale = 'en'
 
   /**
@@ -66,10 +59,8 @@ export class GuildConfig extends BaseEntity {
    * Australia/Perth
    * Europe/Zurich
    */
-  @Column({
-    length: 45,
-    type: 'varchar',
-  })
+  @Column({ type: 'varchar' })
+  @IsOptional()
   timezone?: IANAZone
 
   /**

--- a/src/models/validators/time-zone.ts
+++ b/src/models/validators/time-zone.ts
@@ -1,0 +1,19 @@
+import { IANAZone } from 'luxon'
+import { ValidationOptions, registerDecorator } from 'class-validator'
+
+export function IsTimeZone(validationOptions?: ValidationOptions) {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  return function (object: Object, propertyName: string): void {
+    registerDecorator({
+      name: 'IsTimeZone',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(timeZone: IANAZone): boolean {
+          return timeZone.isValid
+        },
+      },
+    })
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
 
   "compilerOptions": {
     "outDir": "dist",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"
   integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
 
+"@types/validator@13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.0.0.tgz#365f1bf936aeaddd0856fc41aa1d6f82d88ee5b3"
+  integrity sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw==
+
 "@typescript-eslint/eslint-plugin@^4.5.0":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.8.2.tgz#cf9102ec800391caa574f589ffe0623cca1d9308"
@@ -371,6 +376,16 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+class-validator@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.12.2.tgz#2ceb72f88873e9c714cf5f9c278cbc71f6f6c8ef"
+  integrity sha512-TDzPzp8BmpsbPhQpccB3jMUE/3pK0TyqamrK0kcx+ZeFytMA+O6q87JZZGObHHnoo9GM8vl/JppIyKWeEA/EVw==
+  dependencies:
+    "@types/validator" "13.0.0"
+    google-libphonenumber "^3.2.8"
+    tslib ">=1.9.0"
+    validator "13.0.0"
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -873,6 +888,11 @@ globby@^11.0.1:
     ignore "^5.1.4"
     merge2 "^1.3.0"
     slash "^3.0.0"
+
+google-libphonenumber@^3.2.8:
+  version "3.2.15"
+  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.15.tgz#3a01dc554dbf83c754f249c16df3605e5d154bb9"
+  integrity sha512-tbCIuzMoH34RdrbFRw5kijAZn/p6JMQvsgtr1glg2ugbwqrMPlOL8pHNK8cyGo9B6SXpcMm4hdyDqwomR+HPRg==
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -1759,6 +1779,11 @@ ts-node@^9.0.0:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
+tslib@>=1.9.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
+
 tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -1836,6 +1861,11 @@ v8-compile-cache@^2.0.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
   integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
+
+validator@13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.0.0.tgz#0fb6c6bb5218ea23d368a8347e6d0f5a70e3bcab"
+  integrity sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Starts adding basic model validations by doing the following

* Adds [class-validator](https://en.wikipedia.org/wiki/Singleton_pattern) for doing model validation
* Adds a `BaseModel` class for Winnie models to inherit from containing common functionality
* Adds basic validations to the `GuildConfig` class using class-validator's built in validators
* Adds a custom validator for IANA Timezones and uses it to validate timezones in `GuildConfig`

Still todo - Add validations for the GuildConfig announcement's channel
