### PR TITLE
Slight tweaks to goals

### DIFF
--- a/db/migration/1607590446829-createGoalTable.ts
+++ b/db/migration/1607590446829-createGoalTable.ts
@@ -34,12 +34,14 @@ export class createGoalTable1607590446829 implements MigrationInterface {
           length: '30',
         },
         {
-          name: 'canceled',
-          type: 'bool',
+          name: 'canceled_at',
+          type: 'timestamp',
+          isNullable: true,
         },
         {
-          name: 'completed',
-          type: 'bool',
+          name: 'completed_at',
+          type: 'timestamp',
+          isNullable: true,
         },
       ],
     })

--- a/db/migration/1607590446829-createGoalTable.ts
+++ b/db/migration/1607590446829-createGoalTable.ts
@@ -34,6 +34,16 @@ export class createGoalTable1607590446829 implements MigrationInterface {
           length: '30',
         },
         {
+          name: 'created_at',
+          type: 'timestamp',
+          isNullable: true,
+        },
+        {
+          name: 'updated_at',
+          type: 'timestamp',
+          isNullable: true,
+        },
+        {
           name: 'canceled_at',
           type: 'timestamp',
           isNullable: true,

--- a/db/migration/1607590446829-createGoalTable.ts
+++ b/db/migration/1607590446829-createGoalTable.ts
@@ -11,7 +11,7 @@ export class createGoalTable1607590446829 implements MigrationInterface {
           isPrimary: true,
         },
         {
-          name: 'goal',
+          name: 'target',
           type: 'int',
         },
         {
@@ -20,7 +20,7 @@ export class createGoalTable1607590446829 implements MigrationInterface {
           enum: ['lines', 'minutes', 'pages', 'words'],
         },
         {
-          name: 'written',
+          name: 'progress',
           type: 'int',
         },
         {

--- a/src/models/goal.ts
+++ b/src/models/goal.ts
@@ -63,14 +63,18 @@ export class Goal extends BaseModel {
   channelId!: Snowflake
 
   /**
-   * Whether or not this goal has been canceled
+   * Timestamp of when this goal was canceled.
+   *
+   * Null if not canceled
    */
-  @Column({ type: 'bool' })
-  canceled = false
+  @Column({ name: 'canceled_at' })
+  canceledAt?: Date
 
   /**
-   * Whether or not this goal has been completed
+   * Timestamp of when this goal was completed.
+   *
+   * Null if not completed
    */
-  @Column({ type: 'bool' })
-  completed = false
+  @Column({ name: 'completed_at' })
+  completedAt?: Date
 }

--- a/src/models/goal.ts
+++ b/src/models/goal.ts
@@ -37,7 +37,7 @@ export class Goal extends BaseEntity {
    * Can be one of pages, words, minutes, lines, or items
    */
   @Column({ name: 'goal_type', type: 'enum', enum: GoalTypes })
-  goalType!: GoalTypes
+  goalType: GoalTypes = GoalTypes.WORDS
 
   /**
    * The progress towards completing the goal.

--- a/src/models/goal.ts
+++ b/src/models/goal.ts
@@ -1,4 +1,5 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
+import { BaseModel } from './base-model'
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
 import { Snowflake } from 'discord.js'
 
 /**
@@ -16,7 +17,7 @@ export enum GoalTypes {
  * Represents a goal users can set.
  */
 @Entity()
-export class Goal extends BaseEntity {
+export class Goal extends BaseModel {
   /**
    * The goal's id.
    */

--- a/src/models/goal.ts
+++ b/src/models/goal.ts
@@ -24,12 +24,12 @@ export class Goal extends BaseEntity {
   id!: number
 
   /**
-   * The progress towards completing the goal.
+   * The target for the goal.
    *
    * example: 5 pages
    */
   @Column()
-  goal!: number
+  target!: number
 
   /**
    * The type of goal for which the user is aiming.
@@ -40,12 +40,12 @@ export class Goal extends BaseEntity {
   goalType!: GoalTypes
 
   /**
-   * The quantity of successfully goal elements.
+   * The progress towards completing the goal.
    *
    * example: 3 out of 5 pages
    */
   @Column({ type: 'int' })
-  written = 0
+  progess = 0
 
   /**
    * The id of the user that set the goal.

--- a/src/models/goal.ts
+++ b/src/models/goal.ts
@@ -1,5 +1,5 @@
 import { BaseModel } from './base-model'
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
+import { BeforeInsert, BeforeUpdate, Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
 import { Snowflake } from 'discord.js'
 
 /**
@@ -63,6 +63,18 @@ export class Goal extends BaseModel {
   channelId!: Snowflake
 
   /**
+   * The timestamp of when this Emote was created.
+   */
+  @Column({ name: 'created_at' })
+  createdAt!: Date
+
+  /**
+   * The timestamp of the most recent time this Emote was updated.
+   */
+  @Column({ name: 'updated_at' })
+  updatedAt?: Date
+
+  /**
    * Timestamp of when this goal was canceled.
    *
    * Null if not canceled
@@ -77,4 +89,24 @@ export class Goal extends BaseModel {
    */
   @Column({ name: 'completed_at' })
   completedAt?: Date
+
+  /**
+   * Listener for the beforeInsert event.
+   *
+   * Sets the created at timestamp.
+   */
+  @BeforeInsert()
+  onBeforeInsert(): void {
+    this.createdAt = new Date()
+  }
+
+  /**
+   * Listener for the beforeUpdate event.
+   *
+   * Sets the updated at timestamp.
+   */
+  @BeforeUpdate()
+  onBeforeUpdate(): void {
+    this.updatedAt = new Date()
+  }
 }


### PR DESCRIPTION
makes the following changes to goals

* Renames the `goal` attribute to `target` and the `written` attribute to `progress`
* Sets a default value `words` for `goalType`
* Uses the `BaseModel` class as the parent class
* Changes `completed` and `canceled` to use timestamps instead of booleans
* Adds `createdAt` and `updatedAt` fields and uses listeners to set them.