### PR TITLE
Add server Configuration commands

### DIFF
--- a/locales/en/commands.json
+++ b/locales/en/commands.json
@@ -2,20 +2,67 @@
   "defaultError": "**Unknown Error:** I'm sorry, I'm afraid I can't do that. This incident has been logged to the dashboard.",
   "config": {
     "crossGuild": {
-      "enabled": "You have enabled posting your challenges across servers",
+      "enabled": "You have enabled posting your challenges across servers.",
       "disabled": "You have disabled posting your challenges across servers.",
       "invalid": "Invalid value passed for crossGuild. Must be one of true/false.",
       "noValue": "You didn't provide a value to set cross guild to.\n\nSee `{{prefix}}help config crossGuild` for more information.",
       "successfullySet": "Succesfully updated crossGuild setting to: `{{crossGuild}}`."
     },
     "timezone": {
-      "get": "Your timezone is currently set to {{timezone}}",
+      "get": "Your timezone is currently set to {{timezone}}.",
       "invalid": "{{timezone}} is not a real timezone identifer.",
       "noCommand": "You need to provide an to run.\n\nSee `{{prefix}}help config timezone` for more information.",
       "notSet": "You have not yet set a timezone\n\nyou can set one with `{{prefix}}help config set timezone <timezone>`.",
       "noValue": "You didn't provide a timezone to set.\n\nSee `{{prefix}}help config set` for more information.",
+      "reset": "You have successfully unset your timezone.",
+      "set": "You've successfully set your time zone to {{timezone}}.",
+      "unknownCommand": "I don't know that command, use `{{prefix}}help config timezone` for help."
+    }
+  },
+  "server": {
+    "announcement": {
+      "get": "Announcements channel currently set to <#{{channel}}>.",
+      "invalid": "You didn't provide a vaild channel. Please make sure Winnie has permission to read and send messages in the channel you are trying to set.",
+      "noChannel": "You didn't provide a new channel to set. \n\nSee `{{prefix}}help config announcementChannel` for more information.",
+      "noCommand": "You need to provide a command to run.\n\nSee `{{prefix}}help config announcementChannel` for more information.",
+      "notSet": "You have not set announcements channel.\n\nSee `{{prefix}}help server announcementChannel set` to learn how to set a channel.",
+      "reset": "You have successfully unset your announcements channel.",
+      "set": "Announcements channel successfully set to <#{{channel}}>",
+      "unknownCommand": "I don't know that command, use `{{prefix}}help config announcementChannel` for help."
+    },
+    "crossGuild": {
+      "enabled": "You have enabled posting your challenges across servers.",
+      "disabled": "You have disabled posting your challenges across servers.",
+      "invalid": "Invalid value passed for crossGuild. Must be one of true/false.",
+      "noValue": "You didn't provide a value to set cross guild to.\n\nSee `{{prefix}}help server crossGuild` for more information.",
+      "successfullySet": "Succesfully updated crossGuild setting to: `{{crossGuild}}`."
+    },
+    "locale": {
+      "get": "Server locale currently set to: `{{locale}}`.",
+      "invalid": "{{locale}} is an invalide locale. Valid locales are `{{locales}}`.",
+      "noCommand": "You need to provide a command to run.\n\nSee `{{prefix}}help config locale` for more information.",
+      "noLocale": "You didn't provide a new locale to set. \n\nSee `{{prefix}}help config locale` for more information.",
+      "reset": "You have successfully reset the server locale. Your new locale is: `{{locale}}`.",
+      "set": "You have successfully set a new server locale. Your new locale is: `{{locale}}`.",
+      "unknownCommand": "I don't know that command, use `{{prefix}}help config locale` for help."
+    },
+    "prefix": {
+      "get": "The command prefix is currently set to: `{{prefix}}`.",
+      "invalid": "{{prefix}} is an invalid prefix. Prefixes must contain at least one (1) character and no more than three (3).",
+      "noCommand": "You need to provide a command to run.\n\nSee `{{prefix}}help config prefix` for more information.",
+      "noPrefix": "You didn't provide a new prefix to set. \n\nSee `{{prefix}}help config prefix` for more information.",
+      "reset": "You have successfully reset the command prefix. Your new prefix is: `{{prefix}}`.",
+      "set": "You have successfully set a new command prefix. Your new prefix is: `{{prefix}}`.",
+      "unknownCommand": "I don't know that command, use `{{prefix}}help config prefix` for help."
+    },
+    "timezone": {
+      "get": "Your timezone is currently set to {{timezone}}.",
+      "invalid": "{{timezone}} is not a real timezone identifer.",
+      "noCommand": "You need to provide a command to run.\n\nSee `{{prefix}}help config timezone` for more information.",
+      "notSet": "You have not yet set a timezone\n\nyou can set one with `{{prefix}}help config set timezone <timezone>`.",
+      "noValue": "You didn't provide a timezone to set.\n\nSee `{{prefix}}help config set` for more information.",
       "reset": "You have successfully reset your timezone.",
-      "set": "You've successfully set your time zone to {{timezone}}",
+      "set": "You've successfully set your time zone to {{timezone}}.",
       "unknownCommand": "I don't know that command, use `{{prefix}}help config timezone` for help."
     }
   }

--- a/src/commands/config/cross-guild.ts
+++ b/src/commands/config/cross-guild.ts
@@ -45,7 +45,7 @@ const setCrossGuild = async (
  * Command used for getting, setting, and resetting user cross guild settings
  */
 export const ConfigCrossGuildCommand: Command = {
-  name: 'crossGuild',
+  name: 'crossguild',
   execute: async (message: Message, guildConfig: GuildConfig) => {
     const userConfig = await UserConfig.findOrCreate(message.author.id)
     const commandArgs = message.content.split(/ +/).slice(2)

--- a/src/commands/config/cross-guild.ts
+++ b/src/commands/config/cross-guild.ts
@@ -15,7 +15,7 @@ const setCrossGuild = async (
   message: Message, guildConfig: GuildConfig, userConfig: UserConfig, crossGuild?: string
 ): Promise<void> => {
   if (crossGuild == null) {
-    await message.reply(await I18n.translate(guildConfig.locale, 'commands:config.set.noValue', {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:config.crossGuild.noValue', {
       prefix: guildConfig.prefix
     }))
     return
@@ -26,16 +26,16 @@ const setCrossGuild = async (
   } else if (crossGuild.toLowerCase() === 'false') {
     userConfig.crossGuild = false
   } else {
-    await message.reply(await I18n.translate(guildConfig.locale, 'commands:config.set.invalidCrossGuild'))
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:config.crossGuild.invalid'))
     return
   }
 
   await userConfig.save()
 
   if (userConfig.errors.length > 0) {
-    await message.reply(await I18n.translate(guildConfig.locale, 'commands:config.set.invalidCrossGuild'))
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:config.crossGuild.invalid'))
   } else {
-    await message.reply(await I18n.translate(guildConfig.locale, 'commands:config.set.crossGuildSet', {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:config.crossGuild.successfullySet', {
       crossGuild: userConfig.crossGuild
     }))
   }
@@ -62,7 +62,7 @@ export const ConfigCrossGuildCommand: Command = {
       case 'get':
         await message.reply(await I18n.translate(
           guildConfig.locale,
-        `commands:config.get.crossGuild${userConfig.crossGuild ? 'Enabled' : 'Disabled'}`
+        `commands:config.crossGuild.${userConfig.crossGuild ? 'enabled' : 'disabled'}`
         ))
         break
       case 'set':

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,9 +1,11 @@
 import { Command } from '../../types/command'
+import { ConfigCrossGuildCommand } from './cross-guild'
 import { ConfigTimezoneCommand } from './timezone'
 import { GuildConfig } from '../../models'
 import { Message } from 'discord.js'
 
 const subcommands = [
+  ConfigCrossGuildCommand,
   ConfigTimezoneCommand
 ]
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,7 +1,9 @@
 import { ConfigCommand } from './config'
+import { ServerConfigCommand } from './server'
 
 export const Commands = {
   commandList: [
-    ConfigCommand
+    ConfigCommand,
+    ServerConfigCommand
   ]
 }

--- a/src/commands/server/announcements-channel.ts
+++ b/src/commands/server/announcements-channel.ts
@@ -1,0 +1,95 @@
+import { Command } from '../../types/command'
+import { GuildConfig } from '../../models'
+import { I18n } from '../../core/i18n'
+import { Message } from 'discord.js'
+
+/**
+ * Command used for getting, setting, and resetting a guild's accouncements channel.
+ */
+export const ServerAnnouncementsChannelCommand: Command = {
+  name: 'announcementchannel',
+  execute: async (message: Message, guildConfig: GuildConfig) => {
+    const commandArgs = message.content.split(/ +/).slice(2)
+    const command = commandArgs.shift()
+
+    if (command == null) {
+      await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.announcement.noCommand', {
+        prefix: guildConfig.prefix
+      }))
+      return
+    }
+
+    switch (command) {
+      case 'get':
+        await getAnnouncementsChannel(message, guildConfig)
+        break
+      case 'set':
+        await setAnnouncementsChannel(message, guildConfig)
+        break
+      case 'reset':
+        await resetAnnouncementsChannel(message, guildConfig)
+        break
+      default:
+        await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.announcement.unknownCommand', {
+          prefix: guildConfig.prefix
+        }))
+    }
+  }
+}
+
+/**
+ * Gets the current channel for the guild.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ */
+async function getAnnouncementsChannel (message: Message, guildConfig: GuildConfig): Promise<void> {
+  if (guildConfig.announcementsChannelId != null) {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.announcement.get', {
+      channel: guildConfig.announcementsChannelId
+    }))
+  } else {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.announcement.notSet', {
+      prefix: guildConfig.prefix
+    }))
+  }
+}
+
+/**
+ * Sets a new channel for the guild.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ */
+async function setAnnouncementsChannel (message: Message, guildConfig: GuildConfig): Promise<void> {
+  const newChannelId = message.mentions.channels.firstKey() // Grab the ID of the first channel mentioned
+
+  if (newChannelId == null) {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.announcement.noChannel'))
+    return
+  }
+
+  guildConfig.announcementsChannelId = newChannelId
+  await guildConfig.save()
+
+  if (guildConfig.errors.length > 0) {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.announcement.invalid'))
+  } else {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.announcement.set', {
+      channel: guildConfig.announcementsChannelId
+    }))
+  }
+}
+
+/**
+ * Reset the guild's channel to the default.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ */
+async function resetAnnouncementsChannel (message: Message, guildConfig: GuildConfig): Promise<void> {
+  guildConfig.announcementsChannelId = null
+  await guildConfig.save()
+
+  await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.announcement.reset'))
+}

--- a/src/commands/server/cross-guild.ts
+++ b/src/commands/server/cross-guild.ts
@@ -46,7 +46,7 @@ export const ServerCrossGuildCommand: Command = {
 async function getCrossGuild (message: Message, guildConfig: GuildConfig): Promise<void> {
   await message.reply(await I18n.translate(
     guildConfig.locale,
-    `commands:server.get.crossGuild${guildConfig.crossGuild ? 'Enabled' : 'Disabled'}`
+    `commands:server.crossGuild.${guildConfig.crossGuild ? 'enabled' : 'disabled'}`
   ))
 }
 
@@ -59,7 +59,7 @@ async function getCrossGuild (message: Message, guildConfig: GuildConfig): Promi
  */
 async function setCrossGuild (message: Message, guildConfig: GuildConfig, crossGuild?: string): Promise<void> {
   if (crossGuild == null) {
-    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.set.noValue', {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.crossGuild.noValue', {
       prefix: guildConfig.prefix
     }))
     return
@@ -70,16 +70,16 @@ async function setCrossGuild (message: Message, guildConfig: GuildConfig, crossG
   } else if (crossGuild.toLowerCase() === 'false') {
     guildConfig.crossGuild = false
   } else {
-    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.set.invalidCrossGuild'))
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.crossGuild.invalid'))
     return
   }
 
   await guildConfig.save()
 
   if (guildConfig.errors.length > 0) {
-    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.set.invalidCrossGuild'))
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.crossGuild.invalid'))
   } else {
-    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.set.crossGuildSet', {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.crossGuild.successfullySet', {
       crossGuild: guildConfig.crossGuild
     }))
   }

--- a/src/commands/server/cross-guild.ts
+++ b/src/commands/server/cross-guild.ts
@@ -1,0 +1,99 @@
+import { Command } from '../../types/command'
+import { GuildConfig } from '../../models'
+import { I18n } from '../../core/i18n'
+import { Message } from 'discord.js'
+
+/**
+ * Command used for getting, setting, and resetting server cross guild settings
+ */
+export const ServerCrossGuildCommand: Command = {
+  name: 'crossguild',
+  execute: async (message: Message, guildConfig: GuildConfig) => {
+    const commandArgs = message.content.split(/ +/).slice(2)
+    const command = commandArgs.shift()
+
+    if (command == null) {
+      await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.crossGuild.noCommand', {
+        prefix: guildConfig.prefix
+      }))
+      return
+    }
+
+    switch (command) {
+      case 'get':
+        await getCrossGuild(message, guildConfig)
+        break
+      case 'set':
+        await setCrossGuild(message, guildConfig, commandArgs.shift())
+        break
+      case 'reset':
+        await resetCrossGuild(message, guildConfig)
+        break
+      default:
+        await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.crossGuild.unknownCommand', {
+          prefix: guildConfig.prefix
+        }))
+    }
+  }
+}
+
+/**
+ * Gets the current vaule of the crossGuild setting.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ */
+async function getCrossGuild (message: Message, guildConfig: GuildConfig): Promise<void> {
+  await message.reply(await I18n.translate(
+    guildConfig.locale,
+    `commands:server.get.crossGuild${guildConfig.crossGuild ? 'Enabled' : 'Disabled'}`
+  ))
+}
+
+/**
+ * Updates the cross guild attribute.
+ *
+ * @param message The message from which the command was ran
+ * @param guildConfig the config object for the current guild
+ * @param crossGuild the new value of the cross guild attribute
+ */
+async function setCrossGuild (message: Message, guildConfig: GuildConfig, crossGuild?: string): Promise<void> {
+  if (crossGuild == null) {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.set.noValue', {
+      prefix: guildConfig.prefix
+    }))
+    return
+  }
+
+  if (crossGuild.toLowerCase() === 'true') {
+    guildConfig.crossGuild = true
+  } else if (crossGuild.toLowerCase() === 'false') {
+    guildConfig.crossGuild = false
+  } else {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.set.invalidCrossGuild'))
+    return
+  }
+
+  await guildConfig.save()
+
+  if (guildConfig.errors.length > 0) {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.set.invalidCrossGuild'))
+  } else {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.set.crossGuildSet', {
+      crossGuild: guildConfig.crossGuild
+    }))
+  }
+}
+
+/**
+ * Reset the guild's crossGuild setting.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ */
+async function resetCrossGuild (message: Message, guildConfig: GuildConfig): Promise<void> {
+  guildConfig.crossGuild = true
+  await guildConfig.save()
+
+  await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.crossGuild.reset'))
+}

--- a/src/commands/server/index.ts
+++ b/src/commands/server/index.ts
@@ -1,0 +1,41 @@
+import { Command } from '../../types/command'
+import { GuildConfig } from '../../models'
+import { Message } from 'discord.js'
+import { ServerAnnouncementsChannelCommand } from './announcements-channel'
+import { ServerCrossGuildCommand } from './cross-guild'
+import { ServerLocaleCommand } from './locale'
+import { ServerPrefixCommand } from './prefix'
+import { ServerTimezoneCommand } from './timezone'
+
+const subcommands = [
+  ServerAnnouncementsChannelCommand,
+  ServerCrossGuildCommand,
+  ServerLocaleCommand,
+  ServerPrefixCommand,
+  ServerTimezoneCommand
+]
+
+/**
+ * The config command is used for doing basic CRUD operations
+ * for guild configuration
+ */
+export const ServerConfigCommand: Command = {
+  name: 'server',
+  execute: async (message: Message, guildConfig: GuildConfig) => {
+    const commandName = message.content
+      .split(/ +/)[1] // Split the message, at spaces, into an array of strings and grab the second element
+      ?.toLowerCase() // Convert the subcommand name to lowercase for case insensitive matching
+
+    if (commandName == null) { return }
+
+    const command = subcommands.find((command) => {
+      return command.name === commandName || command.aliases?.includes(commandName)
+    })
+
+    if (command == null) { return }
+    if (message.member == null) { return }
+    if (command.requiredPermissions != null && !message.member.permissions.has(command.requiredPermissions)) { return }
+
+    await command.execute(message, guildConfig)
+  }
+}

--- a/src/commands/server/locale.ts
+++ b/src/commands/server/locale.ts
@@ -1,0 +1,96 @@
+import { Command } from '../../types/command'
+import { GuildConfig } from '../../models'
+import { I18n } from '../../core/i18n'
+import { Message } from 'discord.js'
+
+/**
+ * Command used for getting, setting, and resetting a guild's locale.
+ */
+export const ServerLocaleCommand: Command = {
+  name: 'locale',
+  execute: async (message: Message, guildConfig: GuildConfig) => {
+    const commandArgs = message.content.split(/ +/).slice(2)
+    const command = commandArgs.shift()
+
+    if (command == null) {
+      await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.locale.noCommand', {
+        prefix: guildConfig.prefix
+      }))
+      return
+    }
+
+    switch (command) {
+      case 'get':
+        await getLocale(message, guildConfig)
+        break
+      case 'set':
+        await setLocale(message, guildConfig, commandArgs.shift())
+        break
+      case 'reset':
+        await resetLocale(message, guildConfig)
+        break
+      default:
+        await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.locale.unknownCommand', {
+          prefix: guildConfig.prefix
+        }))
+    }
+  }
+}
+
+/**
+ * Gets the current locale for the guild.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ */
+async function getLocale (message: Message, guildConfig: GuildConfig): Promise<void> {
+  await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.locale.get', {
+    locale: guildConfig.locale
+  }))
+}
+
+/**
+ * Sets a new locale for the guild.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ * @param prefix The new prefix to use for the guild
+ */
+async function setLocale (message: Message, guildConfig: GuildConfig, locale?: string): Promise<void> {
+  if (locale == null) {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.locale.noLocale'))
+    return
+  }
+
+  const oldLocale = guildConfig.locale
+
+  guildConfig.locale = locale
+  await guildConfig.save()
+
+  if (guildConfig.errors.length > 0) {
+    guildConfig.locale = oldLocale
+    await message.reply(await I18n.translate(oldLocale, 'commands:server.locale.invalid', {
+      locale,
+      locales: I18n.SUPPORTED_LANGUAGES.toString()
+    }))
+  } else {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.locale.set', {
+      locale: guildConfig.locale
+    }))
+  }
+}
+
+/**
+ * Reset the guild's command locale to the default.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ */
+async function resetLocale (message: Message, guildConfig: GuildConfig): Promise<void> {
+  guildConfig.locale = GuildConfig.DEFAULT_LOCALE
+  await guildConfig.save()
+
+  await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.locale.reset', {
+    locale: guildConfig.locale
+  }))
+}

--- a/src/commands/server/prefix.ts
+++ b/src/commands/server/prefix.ts
@@ -1,0 +1,90 @@
+import { Command } from '../../types/command'
+import { GuildConfig } from '../../models'
+import { I18n } from '../../core/i18n'
+import { Message } from 'discord.js'
+
+/**
+ * Command used for getting, setting, and resetting a guild's command prefix.
+ */
+export const ServerPrefixCommand: Command = {
+  name: 'prefix',
+  execute: async (message: Message, guildConfig: GuildConfig) => {
+    const commandArgs = message.content.split(/ +/).slice(2)
+    const command = commandArgs.shift()
+
+    if (command == null) {
+      await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.prefix.noCommand', {
+        prefix: guildConfig.prefix
+      }))
+      return
+    }
+
+    switch (command) {
+      case 'get':
+        await getPrefix(message, guildConfig)
+        break
+      case 'set':
+        await setPrefix(message, guildConfig, commandArgs.shift())
+        break
+      case 'reset':
+        await resetPrefix(message, guildConfig)
+        break
+      default:
+        await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.prefix.unknownCommand', {
+          prefix: guildConfig.prefix
+        }))
+    }
+  }
+}
+
+/**
+ * Gets the current prefix for the guild.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ */
+async function getPrefix (message: Message, guildConfig: GuildConfig): Promise<void> {
+  await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.prefix.get', {
+    prefix: guildConfig.prefix
+  }))
+}
+
+/**
+ * Sets a new prefix for the guild.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ * @param prefix The new prefix to use for the guild
+ */
+async function setPrefix (message: Message, guildConfig: GuildConfig, prefix?: string): Promise<void> {
+  if (prefix == null) {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.prefix.noPrefix'))
+    return
+  }
+
+  guildConfig.prefix = prefix
+  await guildConfig.save()
+
+  if (guildConfig.errors.length > 0) {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.prefix.invalid', { prefix }))
+  } else {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.prefix.set', {
+      prefix: guildConfig.prefix
+    }))
+  }
+}
+
+/**
+ * Reset the guild's command prefix to the default.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ */
+async function resetPrefix (message: Message, guildConfig: GuildConfig): Promise<void> {
+  guildConfig.prefix = GuildConfig.DEFAULT_PREFIX
+  await guildConfig.save()
+
+  await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.prefix.reset', {
+    prefix: guildConfig.prefix
+  }))
+}

--- a/src/commands/server/timezone.ts
+++ b/src/commands/server/timezone.ts
@@ -1,0 +1,97 @@
+import { Command } from '../../types/command'
+import { GuildConfig } from '../../models'
+import { I18n } from '../../core/i18n'
+import { IANAZone } from 'luxon'
+import { Message } from 'discord.js'
+
+/**
+ * Command used for getting, setting, and resetting guild timezone settings
+ */
+export const ServerTimezoneCommand: Command = {
+  name: 'timezone',
+  execute: async (message: Message, guildConfig: GuildConfig) => {
+    const commandArgs = message.content.split(/ +/).slice(2)
+    const command = commandArgs.shift()
+
+    if (command == null) {
+      await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.timezone.noCommand', {
+        prefix: guildConfig.prefix
+      }))
+      return
+    }
+
+    switch (command) {
+      case 'get':
+        await getTimezone(message, guildConfig)
+        break
+      case 'set':
+        await setTimezone(message, guildConfig, commandArgs.shift())
+        break
+      case 'reset':
+        await resetTimezone(message, guildConfig)
+        break
+      default:
+        await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.timezone.unknownCommand', {
+          prefix: guildConfig.prefix
+        }))
+    }
+  }
+}
+
+/**
+ * Gets the current timezone for the guild.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ */
+async function getTimezone (message: Message, guildConfig: GuildConfig): Promise<void> {
+  if (guildConfig.timezone != null) {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.timezone.get', {
+      timezone: guildConfig.timezone.name
+    }))
+  } else {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.timezone.notSet', {
+      prefix: guildConfig.prefix
+    }))
+  }
+}
+
+/**
+ * Sets a new timezone for a guild.
+ *
+ * @param message The message from which the command was ran
+ * @param guildConfig the config object for the current guild
+ * @param timezone the new timezone
+ */
+async function setTimezone (message: Message, guildConfig: GuildConfig, timezone?: string): Promise<void> {
+  if (timezone == null) {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.timezone.noValue', {
+      prefix: guildConfig.prefix
+    }))
+    return
+  }
+
+  guildConfig.timezone = new IANAZone(timezone)
+  await guildConfig.save()
+
+  if (guildConfig.errors.length > 0) {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.timezone.invalid', { timezone }))
+  } else {
+    await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.timezone.set', {
+      timezone: guildConfig.timezone.name
+    }))
+  }
+}
+
+/**
+ * Reset the guild's timezone to null.
+ *
+ * @param message The message which triggered the command.
+ * @param guildConfig The configuration object for the guild.
+ */
+async function resetTimezone (message: Message, guildConfig: GuildConfig): Promise<void> {
+  guildConfig.timezone = null
+  await guildConfig.save()
+
+  await message.reply(await I18n.translate(guildConfig.locale, 'commands:server.timezone.reset'))
+}

--- a/src/models/guild-config.ts
+++ b/src/models/guild-config.ts
@@ -58,10 +58,16 @@ export class GuildConfig extends BaseModel {
    * Australia/Perth
    * Europe/Zurich
    */
-  @Column({ type: 'varchar' })
-  @IsOptional()
+  @Column({
+    type: 'varchar',
+    transformer: {
+      to: (value: IANAZone) => value?.name,
+      from: (value: string) => value === null ? null : new IANAZone(value),
+    },
+  })
   @IsTimeZone()
-  timezone?: IANAZone
+  @IsOptional()
+  timezone?: IANAZone | null
 
   /**
    * Finds the config object for a given guild id.

--- a/src/models/guild-config.ts
+++ b/src/models/guild-config.ts
@@ -12,6 +12,9 @@ import { Permissions, Snowflake } from 'discord.js'
  */
 @Entity()
 export class GuildConfig extends BaseModel {
+  static DEFAULT_PREFIX = '!'
+  static DEFAULT_LOCALE = 'en'
+
   /**
    * The Discord ID of the guild this configuration object represents.
    */
@@ -24,7 +27,7 @@ export class GuildConfig extends BaseModel {
    */
   @Column({ type: 'varchar' })
   @Length(1, 3)
-  prefix = '!'
+  prefix = GuildConfig.DEFAULT_PREFIX
 
   /**
    * The Discord ID of the channel in which announcements should be sent.
@@ -35,7 +38,7 @@ export class GuildConfig extends BaseModel {
   @IsChannelWithPermission(Permissions.FLAGS.SEND_MESSAGES)
   @MaxLength(30)
   @IsOptional()
-  announcementsChannelId?: Snowflake
+  announcementsChannelId?: Snowflake | null
 
   /**
    * Whether or not challenges created in this guild are automatically hidden
@@ -48,7 +51,7 @@ export class GuildConfig extends BaseModel {
    */
   @Column({ type: 'varchar' })
   @IsIn(I18n.SUPPORTED_LANGUAGES)
-  locale = 'en'
+  locale = GuildConfig.DEFAULT_LOCALE
 
   /**
    * A default timezone for the guild.
@@ -62,8 +65,8 @@ export class GuildConfig extends BaseModel {
     type: 'varchar',
     transformer: {
       to: (value: IANAZone) => value?.name,
-      from: (value: string) => value === null ? null : new IANAZone(value),
-    },
+      from: (value: string) => value === null ? null : new IANAZone(value)
+    }
   })
   @IsTimeZone()
   @IsOptional()


### PR DESCRIPTION
Adds commands for setting, reading and resetting guild configuration properties

* `announcementChannel` - Set the channel Winnie posts daily scheduled messages in
* `crossGuild` - Sets whether or not challenges are shown across all guilds
* `locale` - Set the language Winnie's messages are in
* `prefix` - Set the command prefix Winnie uses
* `timezone` - Sets the timezone your server is in