### PR TITLE
Fix missing substring identifier on server tz set

### DIFF
--- a/src/commands/server/timezone.ts
+++ b/src/commands/server/timezone.ts
@@ -84,7 +84,7 @@ async function set (interaction: CommandInteraction, guildConfig: GuildConfig): 
   await guildConfig.save()
 
   if (guildConfig.errors.length > 0) {
-    await interaction.reply(await I18n.translate(guildConfig.locale, 'commands:server.timezone.set.error'))
+    await interaction.reply(await I18n.translate(guildConfig.locale, 'commands:server.timezone.set.error.invalidValue'))
   } else {
     await interaction.reply(await I18n.translate(guildConfig.locale, 'commands:server.timezone.set.success', {
       timezone: guildConfig.timezone.name


### PR DESCRIPTION
# Description of pull request

This PR corrects the localisation key for invalid values going into `/server timezone set`.
