### PR TITLE
Cleanup of old goal workers in script

### DIFF
--- a/start-winnie.sh
+++ b/start-winnie.sh
@@ -7,8 +7,6 @@ yarn typeorm migration:run
 
 cp ./services/*.service /lib/systemd/system/
 
-sudo systemctl stop goal-worker.service
-sudo systemctl revert goal-worker.service
 sudo systemctl stop goal-worker@1.service
 sudo systemctl enable goal-worker@1.service
 sudo systemctl start goal-worker@1.service


### PR DESCRIPTION
# Description of pull request

This pull request removes the cleanup steps required to migrate from one worker to multiple.  (CI can be skipped using `[skip ci]` when merging.)