### PR TITLE
Add a column for starting words to the challenge totals table

### DIFF
--- a/db/migration/1640665500573-addStartingWordsColumn.ts
+++ b/db/migration/1640665500573-addStartingWordsColumn.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class addStartingWordsColumn1640665500573 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn('challenge_totals', 
+      new TableColumn({
+        name: 'start_count',
+        type: 'int',
+        default: 0
+      })
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('challenge_totals', 'start_count')
+  }
+}

--- a/db/migration/1640665500573-addStartingWordsColumn.ts
+++ b/db/migration/1640665500573-addStartingWordsColumn.ts
@@ -1,8 +1,8 @@
-import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm'
 
 export class addStartingWordsColumn1640665500573 implements MigrationInterface {
-  public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.addColumn('challenge_totals', 
+  public async up (queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn('challenge_totals',
       new TableColumn({
         name: 'start_count',
         type: 'int',
@@ -11,7 +11,7 @@ export class addStartingWordsColumn1640665500573 implements MigrationInterface {
     )
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
+  public async down (queryRunner: QueryRunner): Promise<void> {
     await queryRunner.dropColumn('challenge_totals', 'start_count')
   }
 }

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -11,7 +11,7 @@ module.exports = {
     'dist/db/migration/**/*.js'
   ],
   cli: {
-    entitiesDir: 'dist/src/models',
-    migrationsDir: 'dist/db/migration'
+    entitiesDir: 'src/models',
+    migrationsDir: 'db/migration'
   }
 }


### PR DESCRIPTION
# Description of pull request

This pull request adds a column for starting words ([items|lines|minutes|pages]) to the challenge totals table.  This will allow users to input their starting word count when they join a challenge, meaning that we can then dynamically calculate a challenge total from the total number of words in their document at the end of the challenge.