### PR TITLE
Edit Github Actions to work with main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   workflow_run:
     workflows: ["Build Bot"]
-    branches: [main-2.0]
+    branches: [main]
     types: 
       - completed
 


### PR DESCRIPTION
# Description of pull request

This pull request reconfigures the Github Actions workflow to work with a default branch named `main`.